### PR TITLE
feat(agent): add PR review agent and reorganize agent structure

### DIFF
--- a/agent/package.json
+++ b/agent/package.json
@@ -4,9 +4,10 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "agent": "tsx src/agent.ts",
+    "agent": "tsx src/agents/agent.ts",
     "webhook": "tsx src/webhook.ts",
-    "issues": "tsx src/issue-agent.ts"
+    "issues": "tsx src/agents/issue-agent.ts",
+    "review": "tsx src/agents/review-agent.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",

--- a/agent/src/agents/agent.ts
+++ b/agent/src/agents/agent.ts
@@ -1,8 +1,8 @@
 import Anthropic from "@anthropic-ai/sdk";
 import "dotenv/config";
-import { executeTool, toolDefinitions } from "./tools.js";
-import { systemPrompt } from "./prompts.js";
-import { createPullRequest } from "./github.js";
+import { executeTool, toolDefinitions } from "../tools.js";
+import { systemPrompt } from "../prompts.js";
+import { createPullRequest } from "../github.js";
 
 const client = new Anthropic();
 
@@ -97,7 +97,7 @@ After the test passes:
 }
 
 // Only run as CLI when executed directly, not when imported by webhook.ts
-const isMain = process.argv[1]?.endsWith("agent.ts") || process.argv[1]?.endsWith("agent.js");
+const isMain = process.argv[1]?.includes("agents/agent");
 if (isMain) {
   const command = process.argv[2];
   const issueNumber = process.argv[3] ? parseInt(process.argv[3]) : undefined;

--- a/agent/src/agents/issue-agent.ts
+++ b/agent/src/agents/issue-agent.ts
@@ -9,8 +9,8 @@
  */
 import { readFileSync } from "fs";
 import "dotenv/config";
-import { createIssue, ensureLabelExists, listOpenIssues } from "./github.js";
-import { REPO_ROOT } from "./prompts.js";
+import { createIssue, ensureLabelExists, listOpenIssues } from "../github.js";
+import { REPO_ROOT } from "../prompts.js";
 
 const DRY_RUN = process.argv.includes("--dry-run");
 

--- a/agent/src/agents/review-agent.ts
+++ b/agent/src/agents/review-agent.ts
@@ -1,0 +1,99 @@
+import Anthropic from "@anthropic-ai/sdk";
+import "dotenv/config";
+import { executeTool, toolDefinitions, submitReviewToolDefinition } from "../tools.js";
+import { REPO_ROOT } from "../prompts.js";
+import { reviewRules } from "../rules.js";
+import { getPullRequestDiff, submitReview } from "../github.js";
+
+const client = new Anthropic();
+
+const systemPrompt = `
+You are a senior engineer reviewing pull requests for a Solana token CLI project.
+
+## Your task
+Review the provided PR diff against the rules below. Then:
+1. Read the relevant source files to verify completeness
+2. Decide: APPROVE or REQUEST_CHANGES
+3. Write a concise review comment explaining your decision
+4. Call submit_review with your decision and comment
+
+## Codebase
+Repo root: ${REPO_ROOT}
+Key files:
+- cli/src/lib.rs        — CLI business logic
+- cli/src/main.rs       — CLI entrypoint
+- cli/tests/integration.rs — Integration tests
+
+${reviewRules}
+`;
+
+const reviewToolDefinitions = [...toolDefinitions, submitReviewToolDefinition];
+
+export async function runReviewAgent(prNumber: number): Promise<void> {
+  console.log(`\n🔍 Review agent starting — PR #${prNumber}\n`);
+
+  const diff = await getPullRequestDiff(prNumber);
+
+  const messages: Anthropic.MessageParam[] = [
+    {
+      role: "user",
+      content: `Review PR #${prNumber}.\n\nDiff:\n\`\`\`diff\n${diff}\n\`\`\``,
+    },
+  ];
+
+  while (true) {
+    const response = await client.messages.create({
+      model: "claude-sonnet-4-6",
+      max_tokens: 4096,
+      system: systemPrompt,
+      tools: reviewToolDefinitions,
+      messages,
+    });
+
+    console.log(`[review-agent] stop_reason: ${response.stop_reason}`);
+
+    messages.push({ role: "assistant", content: response.content });
+
+    if (response.stop_reason === "end_turn") {
+      console.log("\n✅ Review agent finished\n");
+      break;
+    }
+
+    const toolResults: Anthropic.ToolResultBlockParam[] = [];
+    for (const block of response.content) {
+      if (block.type !== "tool_use") continue;
+
+      console.log(`[tool] ${block.name}(${JSON.stringify(block.input)})`);
+
+      let result: string;
+      if (block.name === "submit_review") {
+        const { event, body } = block.input as { event: "APPROVE" | "REQUEST_CHANGES"; body: string };
+        await submitReview(prNumber, event, body);
+        result = `Review submitted: ${event}`;
+        console.log(`\n📝 Review submitted: ${event}\n`);
+      } else {
+        result = executeTool(block.name, block.input as Record<string, string>);
+      }
+
+      console.log(`[tool] → ${result.slice(0, 120)}${result.length > 120 ? "…" : ""}\n`);
+
+      toolResults.push({ type: "tool_result", tool_use_id: block.id, content: result });
+    }
+
+    messages.push({ role: "user", content: toolResults });
+  }
+}
+
+// Run as CLI: npx tsx src/review-agent.ts <pr-number>
+const isMain = process.argv[1]?.includes("agents/review-agent");
+if (isMain) {
+  const prNumber = parseInt(process.argv[2]);
+  if (!prNumber) {
+    console.error("Usage: tsx src/review-agent.ts <pr-number>");
+    process.exit(1);
+  }
+  runReviewAgent(prNumber).catch((err) => {
+    console.error("Review agent error:", err);
+    process.exit(1);
+  });
+}

--- a/agent/src/github.ts
+++ b/agent/src/github.ts
@@ -48,6 +48,30 @@ export async function listOpenIssues(): Promise<{ title: string; number: number 
   return data.map((i) => ({ title: i.title, number: i.number }));
 }
 
+export async function getPullRequestDiff(prNumber: number): Promise<string> {
+  const { data } = await octokit.pulls.get({
+    owner,
+    repo,
+    pull_number: prNumber,
+    mediaType: { format: "diff" },
+  });
+  return data as unknown as string;
+}
+
+export async function submitReview(
+  prNumber: number,
+  event: "APPROVE" | "REQUEST_CHANGES" | "COMMENT",
+  body: string
+): Promise<void> {
+  await octokit.pulls.createReview({
+    owner,
+    repo,
+    pull_number: prNumber,
+    event,
+    body,
+  });
+}
+
 export async function ensureLabelExists(
   name: string,
   color: string = "0075ca",

--- a/agent/src/rules.ts
+++ b/agent/src/rules.ts
@@ -1,0 +1,38 @@
+/**
+ * Review rules for the PR Review Agent.
+ * Update these rules to change how the agent evaluates pull requests.
+ */
+
+export const reviewRules = `
+## Code Review Rules
+
+### Correctness
+- PDA must be derived using: Pubkey::find_program_address(&[b"token", owner.as_ref(), mint.as_ref()], &ID)
+- Pubkeys must be parsed from strings using Pubkey::from_str().context("...")
+- Instruction must be built using the generated:: types (e.g. generated::burn::Burn { amount })
+- Transaction must be sent via program.request().instruction(instruction).send()
+- Authority/owner must always be the payer keypair
+
+### Test Quality
+- Must use #[test] not #[tokio::test]
+- Must use setup_validator() and setup_program() helpers
+- Must assert on-chain state after the transaction — not just assert!(result.is_ok())
+- Must derive the PDA to fetch and verify the account state
+- Must chain prerequisites in order: init → create_account → mint_tokens → ...
+
+### Code Style
+- Functions must be synchronous — no async/await
+- Errors must use anyhow::Result and .context() for descriptive messages
+- Output must use the ✓ prefix convention (e.g. println!("✓ Tokens burned"))
+- Function signature must match the pattern: pub fn <command>(program, payer, mint, ...) -> Result<()>
+
+### Completeness
+- Function must be exported from cli/src/lib.rs
+- Function must be imported and called in the match arm in cli/src/main.rs
+- Integration test must be added in cli/tests/integration.rs
+- PR title must follow conventional commits: feat(cli): implement <command> command
+
+### Review Outcome
+- APPROVE if all rules pass
+- REQUEST_CHANGES if any rule is violated — cite the specific rule and line number
+`;

--- a/agent/src/tools.ts
+++ b/agent/src/tools.ts
@@ -82,6 +82,27 @@ export const toolDefinitions = [
   },
 ];
 
+// Exported separately — only used by review-agent, not all agents
+export const submitReviewToolDefinition = {
+  name: "submit_review",
+  description: "Submit the final PR review decision.",
+  input_schema: {
+    type: "object" as const,
+    properties: {
+      event: {
+        type: "string",
+        enum: ["APPROVE", "REQUEST_CHANGES"],
+        description: "The review outcome",
+      },
+      body: {
+        type: "string",
+        description: "The review comment explaining the decision",
+      },
+    },
+    required: ["event", "body"],
+  },
+};
+
 export function executeTool(
   name: string,
   input: Record<string, string>

--- a/agent/src/webhook.ts
+++ b/agent/src/webhook.ts
@@ -3,8 +3,17 @@ import { serve } from "@hono/node-server";
 import "dotenv/config";
 import { createHmac, timingSafeEqual } from "crypto";
 import { z } from "zod";
-import { runAgent } from "./agent.js";
+import { runAgent } from "./agents/agent.js";
+import { runReviewAgent } from "./agents/review-agent.js";
 import { commentOnIssue } from "./github.js";
+
+const prPayloadSchema = z.object({
+  action: z.string(),
+  pull_request: z.object({
+    number: z.number(),
+    title: z.string(),
+  }),
+});
 
 const issuePayloadSchema = z.object({
   action: z.string(),
@@ -49,6 +58,33 @@ app.post("/webhook", async (c) => {
   }
 
   const event = c.req.header("x-github-event");
+
+  // Handle pull_request events — trigger the review agent
+  if (event === "pull_request") {
+    const parsed = prPayloadSchema.safeParse(JSON.parse(rawBody));
+    if (!parsed.success) return c.json({ ok: true, skipped: true });
+
+    const { action, pull_request } = parsed.data;
+    if (action !== "opened") return c.json({ ok: true, skipped: true });
+
+    // Only review PRs opened by the implementation agent
+    if (!pull_request.title.startsWith("feat(cli):")) {
+      return c.json({ ok: true, skipped: true });
+    }
+
+    if (DRY_RUN) {
+      console.log(`[webhook] DRY RUN — would review PR #${pull_request.number}`);
+      return c.json({ ok: true, dryRun: true, prNumber: pull_request.number });
+    }
+
+    console.log(`[webhook] Triggering review agent for PR #${pull_request.number}`);
+    runReviewAgent(pull_request.number).catch((err) => {
+      console.error(`[webhook] Review agent error:`, err);
+    });
+
+    return c.json({ ok: true, prNumber: pull_request.number });
+  }
+
   if (event !== "issues") {
     return c.json({ ok: true, skipped: true });
   }


### PR DESCRIPTION
## Summary
- Add `review-agent.ts` — Claude SDK agent that reviews PRs against defined rules
- Add `rules.ts` — configurable review rules (correctness, tests, style, completeness)
- Move agents into `src/agents/` directory (`agent.ts`, `review-agent.ts`, `issue-agent.ts`)
- Add `submit_review` tool definition to `tools.ts`
- Add `getPullRequestDiff` and `submitReview` to `github.ts`
- Wire `pull_request` webhook event to trigger review agent

## Test plan
- [ ] Start webhook server and verify it starts cleanly
- [ ] Run review agent manually: `npm run review <pr-number>`
- [ ] Verify review is posted on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)