### PR TITLE
feat(agent): add orchestrator with review feedback loop

### DIFF
--- a/agent/package.json
+++ b/agent/package.json
@@ -7,7 +7,8 @@
     "agent": "tsx src/agents/agent.ts",
     "webhook": "tsx src/webhook.ts",
     "issues": "tsx src/agents/issue-agent.ts",
-    "review": "tsx src/agents/review-agent.ts"
+    "review": "tsx src/agents/review-agent.ts",
+    "orchestrate": "tsx src/orchestrator.ts"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.39.0",

--- a/agent/src/agents/agent.ts
+++ b/agent/src/agents/agent.ts
@@ -6,22 +6,43 @@ import { createPullRequest } from "../github.js";
 
 const client = new Anthropic();
 
-export async function runAgent(command: string, issueNumber?: number): Promise<void> {
-  console.log(`\n🤖 Agent starting — implementing: ${command}\n`);
+export interface AgentResult {
+  prNumber: number;
+  branch: string;
+}
 
-  const branch = `implement/${command}`;
+export interface FixOptions {
+  prNumber: number;
+  branch: string;
+  reviewComments: string;
+}
 
-  const messages: Anthropic.MessageParam[] = [
-    {
-      role: "user",
-      content: `Implement the "${command}" CLI command following the established pattern in this codebase.
+export async function runAgent(
+  command: string,
+  issueNumber?: number,
+  fix?: FixOptions
+): Promise<AgentResult> {
+  const branch = fix?.branch ?? `implement/${command}`;
+  const mode = fix ? "fix" : "implement";
+
+  console.log(`\n🤖 Agent starting — ${mode}: ${command}\n`);
+
+  const userMessage = fix
+    ? `The PR for the "${command}" command received review feedback. Fix the issues and push to the existing branch: ${branch}.
+
+Review comments:
+${fix.reviewComments}
+
+Push to the existing branch — do NOT create a new branch.`
+    : `Implement the "${command}" CLI command following the established pattern in this codebase.
 
 After the test passes:
 1. Create a new branch: ${branch}
 2. Commit the changed files (cli/src/lib.rs, cli/src/main.rs, cli/tests/integration.rs)
-3. Push the branch to origin
-`,
-    },
+3. Push the branch to origin`;
+
+  const messages: Anthropic.MessageParam[] = [
+    { role: "user", content: userMessage },
   ];
 
   // Agentic loop — keep going until the model stops calling tools
@@ -59,15 +80,20 @@ After the test passes:
         `🤖 Generated with Claude Agent SDK`,
       ].join("\n");
 
+      // In fix mode the PR already exists — no need to open a new one
+      if (fix) {
+        console.log(`\n✅ Fixes pushed to branch: ${branch}\n`);
+        return { prNumber: fix.prNumber, branch };
+      }
+
       console.log(`\n📬 Opening PR for branch: ${branch}`);
-      const prUrl = await createPullRequest(
+      const pr = await createPullRequest(
         `feat(cli): implement ${command} command`,
         prBody,
         branch
       );
-      console.log(`✅ PR opened: ${prUrl}\n`);
-
-      break;
+      console.log(`✅ PR opened: ${pr.url}\n`);
+      return { prNumber: pr.number, branch };
     }
 
     // Execute all tool calls and collect results
@@ -94,6 +120,10 @@ After the test passes:
     // Feed results back to the model
     messages.push({ role: "user", content: toolResults });
   }
+
+  // Unreachable — while(true) always exits via return above.
+  // Required to satisfy TypeScript's exhaustive return check.
+  throw new Error("Agent loop ended without returning a result");
 }
 
 // Only run as CLI when executed directly, not when imported by webhook.ts

--- a/agent/src/agents/review-agent.ts
+++ b/agent/src/agents/review-agent.ts
@@ -29,8 +29,14 @@ ${reviewRules}
 
 const reviewToolDefinitions = [...toolDefinitions, submitReviewToolDefinition];
 
-export async function runReviewAgent(prNumber: number): Promise<void> {
+export interface ReviewResult {
+  approved: boolean;
+  body: string;
+}
+
+export async function runReviewAgent(prNumber: number): Promise<ReviewResult> {
   console.log(`\n🔍 Review agent starting — PR #${prNumber}\n`);
+  let result: ReviewResult = { approved: false, body: "" };
 
   const diff = await getPullRequestDiff(prNumber);
 
@@ -56,7 +62,7 @@ export async function runReviewAgent(prNumber: number): Promise<void> {
 
     if (response.stop_reason === "end_turn") {
       console.log("\n✅ Review agent finished\n");
-      break;
+      return result;
     }
 
     const toolResults: Anthropic.ToolResultBlockParam[] = [];
@@ -65,23 +71,26 @@ export async function runReviewAgent(prNumber: number): Promise<void> {
 
       console.log(`[tool] ${block.name}(${JSON.stringify(block.input)})`);
 
-      let result: string;
       if (block.name === "submit_review") {
         const { event, body } = block.input as { event: "APPROVE" | "REQUEST_CHANGES"; body: string };
         await submitReview(prNumber, event, body);
-        result = `Review submitted: ${event}`;
+        result = { approved: event === "APPROVE", body };
+        const toolResult = `Review submitted: ${event}`;
         console.log(`\n📝 Review submitted: ${event}\n`);
+        toolResults.push({ type: "tool_result", tool_use_id: block.id, content: toolResult });
       } else {
-        result = executeTool(block.name, block.input as Record<string, string>);
+        const toolResult = executeTool(block.name, block.input as Record<string, string>);
+        console.log(`[tool] → ${toolResult.slice(0, 120)}${toolResult.length > 120 ? "…" : ""}\n`);
+        toolResults.push({ type: "tool_result", tool_use_id: block.id, content: toolResult });
       }
-
-      console.log(`[tool] → ${result.slice(0, 120)}${result.length > 120 ? "…" : ""}\n`);
-
-      toolResults.push({ type: "tool_result", tool_use_id: block.id, content: result });
     }
 
     messages.push({ role: "user", content: toolResults });
   }
+
+  // Unreachable — while(true) always exits via return above.
+  // Required to satisfy TypeScript's exhaustive return check.
+  throw new Error("Review agent loop ended without returning a result");
 }
 
 // Run as CLI: npx tsx src/review-agent.ts <pr-number>

--- a/agent/src/github.ts
+++ b/agent/src/github.ts
@@ -10,7 +10,7 @@ export async function createPullRequest(
   body: string,
   branch: string,
   base: string = "main"
-): Promise<string> {
+): Promise<{ url: string; number: number }> {
   const { data } = await octokit.pulls.create({
     owner,
     repo,
@@ -19,7 +19,7 @@ export async function createPullRequest(
     head: branch,
     base,
   });
-  return data.html_url;
+  return { url: data.html_url, number: data.number };
 }
 
 export async function commentOnIssue(
@@ -69,6 +69,19 @@ export async function submitReview(
     pull_number: prNumber,
     event,
     body,
+  });
+}
+
+
+export async function addLabelToPR(
+  prNumber: number,
+  label: string
+): Promise<void> {
+  await octokit.issues.addLabels({
+    owner,
+    repo,
+    issue_number: prNumber,
+    labels: [label],
   });
 }
 

--- a/agent/src/orchestrator.ts
+++ b/agent/src/orchestrator.ts
@@ -1,0 +1,45 @@
+import "dotenv/config";
+import { runAgent } from "./agents/agent.js";
+import { runReviewAgent } from "./agents/review-agent.js";
+import { commentOnIssue, addLabelToPR, ensureLabelExists } from "./github.js";
+
+const MAX_REVIEW_LOOPS = 2;
+
+export async function orchestrate(command: string, issueNumber?: number): Promise<void> {
+  console.log(`\n🎯 Orchestrator starting — command: ${command}\n`);
+
+  // Step 1: implement the command and open a PR
+  const { prNumber, branch } = await runAgent(command, issueNumber);
+
+  let loops = 0;
+
+  while (loops < MAX_REVIEW_LOOPS) {
+    loops++;
+    console.log(`\n🔄 Review loop ${loops}/${MAX_REVIEW_LOOPS} for PR #${prNumber}\n`);
+
+    // Step 2: review the PR
+    const { approved, body } = await runReviewAgent(prNumber);
+
+    if (approved) {
+      console.log(`\n✅ PR #${prNumber} approved after ${loops} review loop(s)\n`);
+      return;
+    }
+
+    if (loops >= MAX_REVIEW_LOOPS) {
+      // Max loops reached — comment and label for human review
+      console.log(`\n⚠️ Max review loops reached for PR #${prNumber} — escalating to human\n`);
+
+      await ensureLabelExists("needs-human-review", "e4e669", "Max agent review loops reached");
+      await addLabelToPR(prNumber, "needs-human-review");
+      await commentOnIssue(
+        prNumber,
+        `⚠️ **Max review loops (${MAX_REVIEW_LOOPS}) reached without approval.**\n\nLast review feedback:\n\n${body}\n\nHuman review required.`
+      );
+      return;
+    }
+
+    // Step 3: fix the issues and push to the existing branch
+    console.log(`\n🔧 Fixing issues on branch: ${branch}\n`);
+    await runAgent(command, issueNumber, { prNumber, branch, reviewComments: body });
+  }
+}

--- a/agent/src/webhook.ts
+++ b/agent/src/webhook.ts
@@ -3,17 +3,8 @@ import { serve } from "@hono/node-server";
 import "dotenv/config";
 import { createHmac, timingSafeEqual } from "crypto";
 import { z } from "zod";
-import { runAgent } from "./agents/agent.js";
-import { runReviewAgent } from "./agents/review-agent.js";
+import { orchestrate } from "./orchestrator.js";
 import { commentOnIssue } from "./github.js";
-
-const prPayloadSchema = z.object({
-  action: z.string(),
-  pull_request: z.object({
-    number: z.number(),
-    title: z.string(),
-  }),
-});
 
 const issuePayloadSchema = z.object({
   action: z.string(),
@@ -59,32 +50,6 @@ app.post("/webhook", async (c) => {
 
   const event = c.req.header("x-github-event");
 
-  // Handle pull_request events — trigger the review agent
-  if (event === "pull_request") {
-    const parsed = prPayloadSchema.safeParse(JSON.parse(rawBody));
-    if (!parsed.success) return c.json({ ok: true, skipped: true });
-
-    const { action, pull_request } = parsed.data;
-    if (action !== "opened") return c.json({ ok: true, skipped: true });
-
-    // Only review PRs opened by the implementation agent
-    if (!pull_request.title.startsWith("feat(cli):")) {
-      return c.json({ ok: true, skipped: true });
-    }
-
-    if (DRY_RUN) {
-      console.log(`[webhook] DRY RUN — would review PR #${pull_request.number}`);
-      return c.json({ ok: true, dryRun: true, prNumber: pull_request.number });
-    }
-
-    console.log(`[webhook] Triggering review agent for PR #${pull_request.number}`);
-    runReviewAgent(pull_request.number).catch((err) => {
-      console.error(`[webhook] Review agent error:`, err);
-    });
-
-    return c.json({ ok: true, prNumber: pull_request.number });
-  }
-
   if (event !== "issues") {
     return c.json({ ok: true, skipped: true });
   }
@@ -129,11 +94,11 @@ app.post("/webhook", async (c) => {
     return c.json({ ok: true, dryRun: true, command, issueNumber });
   }
 
-  console.log(`[webhook] Triggering agent for command: ${command} (issue #${issueNumber})`);
+  console.log(`[webhook] Triggering orchestrator for command: ${command} (issue #${issueNumber})`);
 
-  // Run the agent in the background — don't block the HTTP response
-  runAgent(command, issueNumber).catch((err) => {
-    console.error(`[webhook] Agent error for ${command}:`, err);
+  // Run the orchestrator in the background — don't block the HTTP response
+  orchestrate(command, issueNumber).catch((err) => {
+    console.error(`[webhook] Orchestrator error for ${command}:`, err);
   });
 
   return c.json({ ok: true, command, issueNumber });


### PR DESCRIPTION
## Summary
- Add `orchestrator.ts` to coordinate implementation and review agents
- Implementation agent supports fix mode — reads review feedback and pushes fixes to existing branch
- Review loop capped at 2 iterations — labels PR with `needs-human-review` and comments on failure
- Agent and review agent now return structured results (`prNumber`, `branch`, `approved`, `body`)
- Remove unused `pull_request` webhook handler (review now triggered by orchestrator directly)

## Test plan
- [ ] Run `npm run orchestrate balance` and verify full loop executes
- [ ] Verify review agent posts a review on the PR
- [ ] Verify fix mode pushes to existing branch without creating a new one
- [ ] Verify `needs-human-review` label is added after max loops

🤖 Generated with [Claude Code](https://claude.com/claude-code)