### PR TITLE
feat(cli): implement mint-info command

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -266,6 +266,23 @@ pub fn burn(
     Ok(())
 }
 
+pub fn mint_info(program: &Program<Rc<Keypair>>, mint: &str) -> Result<()> {
+    let mint_pubkey = Pubkey::from_str(mint).context("Invalid mint address")?;
+
+    // Fetch the on-chain TokenMint account — no transaction needed, this is a read
+    let mint_account: solana_token::TokenMint = program
+        .account(mint_pubkey)
+        .context("Failed to fetch mint account")?;
+
+    println!("✓ Mint info");
+    println!("  Mint address:  {}", mint_pubkey);
+    println!("  Authority:     {}", mint_account.authority);
+    println!("  Total supply:  {}", mint_account.total_supply);
+    println!("  Decimals:      {}", mint_account.decimals);
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,7 +1,7 @@
 use anchor_client::{solana_sdk::commitment_config::CommitmentConfig, Client, Cluster};
 use anyhow::Result;
 use clap::{Parser, Subcommand};
-use solana_token_cli::{burn, create_account, init, load_keypair, mint_tokens, transfer, ID};
+use solana_token_cli::{burn, create_account, init, load_keypair, mint_info, mint_tokens, transfer, ID};
 use std::rc::Rc;
 
 #[derive(Parser)]
@@ -135,8 +135,7 @@ fn main() -> Result<()> {
             println!("  owner: {:?}", owner);
         }
         Commands::MintInfo { mint } => {
-            println!("TODO: implement mint-info command");
-            println!("  mint: {}", mint);
+            mint_info(&program, &mint)?;
         }
     }
 

--- a/cli/tests/integration.rs
+++ b/cli/tests/integration.rs
@@ -7,7 +7,7 @@ use anchor_client::{
 };
 use solana_streamer::socket::SocketAddrSpace;
 use solana_test_validator::{TestValidatorGenesis, UpgradeableProgramInfo};
-use solana_token_cli::{burn, create_account, init, mint_tokens, transfer, ID};
+use solana_token_cli::{burn, create_account, init, mint_info, mint_tokens, transfer, ID};
 use std::io::Write;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -302,4 +302,60 @@ fn test_burn() {
     // Also verify the mint's total_supply was reduced
     let mint_account: solana_token::TokenMint = program.account(mint_pubkey).unwrap();
     assert_eq!(mint_account.total_supply, 700, "total supply should be 700 after burning 300");
+}
+
+#[test]
+fn test_mint_info() {
+    let (validator, payer) = setup_validator();
+    let payer = Rc::new(payer);
+    let program = setup_program(&validator, payer.clone());
+
+    // Generate a mint keypair and save to a temp file so we know its pubkey
+    let mint_keypair = Keypair::new();
+    let mint_pubkey = mint_keypair.pubkey();
+    let mint_bytes = mint_keypair.to_bytes();
+    let mut temp_file = tempfile::NamedTempFile::new().unwrap();
+    temp_file
+        .write_all(
+            serde_json::to_string(&mint_bytes.to_vec())
+                .unwrap()
+                .as_bytes(),
+        )
+        .unwrap();
+    let mint_path = temp_file.path().to_str().unwrap().to_string();
+
+    // Initialize the mint with 6 decimals
+    let init_result = init(&program, &payer, 6, Some(mint_path));
+    assert!(init_result.is_ok(), "init failed: {:?}", init_result.err());
+
+    // Mint some tokens so total_supply is non-zero — first create an account, then mint
+    let create_result = create_account(&program, &payer, &mint_pubkey.to_string(), None);
+    assert!(
+        create_result.is_ok(),
+        "create_account failed: {:?}",
+        create_result.err()
+    );
+
+    let mint_result = mint_tokens(
+        &program,
+        &payer,
+        &mint_pubkey.to_string(),
+        &payer.pubkey().to_string(),
+        500,
+    );
+    assert!(
+        mint_result.is_ok(),
+        "mint_tokens failed: {:?}",
+        mint_result.err()
+    );
+
+    // Fetch mint info via the CLI function — must succeed
+    let result = mint_info(&program, &mint_pubkey.to_string());
+    assert!(result.is_ok(), "mint_info failed: {:?}", result.err());
+
+    // Cross-check the on-chain account directly to verify the printed values are correct
+    let mint_account: solana_token::TokenMint = program.account(mint_pubkey).unwrap();
+    assert_eq!(mint_account.authority, payer.pubkey(), "authority should be the payer");
+    assert_eq!(mint_account.decimals, 6, "decimals should be 6");
+    assert_eq!(mint_account.total_supply, 500, "total supply should be 500");
 }


### PR DESCRIPTION
## Summary
Implements the `mint-info` CLI command.

## Changes
- Added `mint-info` function in `cli/src/lib.rs`
- Wired up match arm in `cli/src/main.rs`
- Added integration test in `cli/tests/integration.rs`

Closes #29

🤖 Generated with Claude Agent SDK